### PR TITLE
adding an onReady method to Togglee to notify when the toggles have been loaded from the external source

### DIFF
--- a/lib/togglee.ts
+++ b/lib/togglee.ts
@@ -6,16 +6,27 @@ import { Toggle } from './models/Toggle'
 export class Togglee {
   private toggles?: any
   private url: string
+  private readyPromise: Promise<void>
+  private ready = false;
+  private readyCallback = () => {
+    this.ready = true;
+  }
 
   constructor(url: string, refreshRate: number, defaults?: Toggle[]) {
-    this.toggles = defaults? mapArrayofToggles(defaults) : undefined
+    this.toggles = defaults ? mapArrayofToggles(defaults) : undefined
     setInterval(this.refreshCache, refreshRate * 1000)
     setTimeout(this.refreshCache, 0)
     this.url = url
+    this.readyPromise = new Promise(this.readyCallback)
   }
 
   public isEnabled(prop: string, context?: any) {
     return this.toggles !== undefined && this.toggles[prop] !== undefined ? this.getValue(prop, context) : false
+  }
+
+  public onReady(): Promise<void> {
+    if (this.ready) return Promise.resolve();
+    return this.readyPromise
   }
 
   private getValue(prop: string, context: any) {
@@ -30,6 +41,7 @@ export class Togglee {
   private refreshCache = async () => {
     try {
       this.toggles = mapArrayofToggles((await axios.get(this.url)).data.toggles)
+      this.readyCallback()
     } catch (error) {
       // empty block
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "togglee",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Kanekotic <alvarojosepl@gmail.com>"
   ],
   "repository": "git@github.com:togglee/togglee.git",
-  "license": "MIT",
+  "license": "APACHE-2.0",
   "homepage": "https://www.togglee.com/",
   "keywords": [
     "serverless",

--- a/test/togglee.spec.ts
+++ b/test/togglee.spec.ts
@@ -18,16 +18,13 @@ describe('Toggle', () => {
       name: 'propTrue',
       type: 'release',
       value: true,
-    }    
-    const propFalse: ReleaseToggle =  {
+    }
+    const propFalse: ReleaseToggle = {
       name: 'propFalse',
       type: 'release',
       value: false,
     }
-    const defaultToggles: Toggle[] = [
-      propTrue,
-      propFalse,
-    ]
+    const defaultToggles: Toggle[] = [propTrue, propFalse]
 
     const subject = new Togglee('http://localhost:7001/somepath', 1000, defaultToggles)
 
@@ -68,5 +65,16 @@ describe('Toggle', () => {
     await sleeper
     expect(subject.isEnabled('propTrue')).toBeTruthy()
     expect(subject.isEnabled('propFalse')).toBeFalsy()
+  })
+
+  it('should call onReady callback after resolving the remote content for first time', (done) => {
+    const subject = new Togglee('http://localhost:7001/somepath', 1000)
+
+    subject
+      .onReady()
+      .then(done)
+      .catch(() => {
+        throw Error('should not be called')
+      })
   })
 })


### PR DESCRIPTION
On a React Application, when the application loads for first time, `Togglee` loads the FeatureToggles from the outside source in parallel. Making that, if we are using the `Togglee` in a render function, to not properly enable/disable the feature until you re-render the component for a second time after `Togglee` successfully loads from the external source.